### PR TITLE
Directly register InteropRegisterer instances

### DIFF
--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/HybridInterpreter.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/HybridInterpreter.java
@@ -337,11 +337,8 @@ public class HybridInterpreter extends Interpreter implements IAsyncCancellable 
 						Class<?> registerClass = classLoader.loadClass(className);
 						Object registerObject = registerClass.newInstance();
 						if (registerObject instanceof InteropRegisterer) {
-							assert recordingFactory.getWrappedFactory() == getCompiledContext().getFactory();
-							getCompiledContext().setFactory(recordingFactory);
-							((InteropRegisterer) registerObject).registerLazy(getContext(), getCompiledContext(), classLoader);
-							getCompiledContext().addConstructors(recordingFactory.getAndClearConstructorRecord());
-							getCompiledContext().setFactory(recordingFactory.getWrappedFactory());
+							//register instantiated InteropRegisterer
+							registerClass(registerObject,classLoader);
 							foundRegisterer = true;
 						} else {
 							throw new IncompatibleJarException(jar, new ClassCastException("Unknown type for InteropRegisterer"));


### PR DESCRIPTION
Allow to register InteropRegisterer instances without the need to package the classes in .jar files. Useful to reduce project complexity by eliminating the need to create additional .jar files and for dynamic class creation.

Created a new pull request for java-bootstrap branch as discussed in metaborg/strategoxt#5
