### PR TITLE
Corrected module name in stblib to match path

### DIFF
--- a/strategoxt/stratego-libraries/lib/spec/collection/hash-table/scoped-finite-map.str
+++ b/strategoxt/stratego-libraries/lib/spec/collection/hash-table/scoped-finite-map.str
@@ -12,7 +12,7 @@
 	end of a scope is completely transparent.
 */
 
-module lang/scoped-finite-map
+module collection/hash-table/scoped-finite-map
 imports 
   collection/hash-table/common
   collection/list/-


### PR DESCRIPTION
Module name of scoped-finite-map did not match the folder where the source file is located in. Adapted the module name to match the folder and the import in stratego-lib-generic.str.
