### PR TITLE
Feature: Pattern-matched term parameters

### DIFF
--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/desugar.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/desugar.str
@@ -4,7 +4,7 @@
  * @author Eelco Visser 1998 - 2004
  */
 
-module desugar
+module stratego/strc/front/desugar
 
 imports 
   Stratego-Sugar
@@ -209,7 +209,7 @@ strategies // "with" strategy
   RecordName =
     ?RDefT(f, _, _, _)
   ; rules(WithContext := <conc-strings> ("rule '", f, "'"))
-
+    
   RecordName =
     ?SDefT(f, _, _, _)
   ; rules(WithContext := <conc-strings> ("strategy '", f, "'"))
@@ -280,6 +280,51 @@ rules
 
   Desugar :
     RDef(f, xs, r) -> RDefT(f, xs, [], r)
+    
+
+// Term parameters in rules and strategies
+
+  // Strategy definition with pattern matched term parameters.
+  Desugar :
+      SDefP(f, xs, xt, s) -> SDefT(f, xs, xt', s')
+      with  (xt', s') := <transform-P-to-T-s(|s)> xt
+    
+  // Rule definition with pattern matched term parameters.
+  Desugar :
+      RDefP(f, xs, xt, RuleNoCond(a, b)) -> RDefT(f, xs, xt', Rule(a, b, [w*]))
+      with  (xt', w*) := <transform-P-to-T-r> xt
+      
+  Desugar :
+      RDefP(f, xs, xt, Rule(a, b, r*)) -> RDefT(f, xs, xt', Rule(a, b, [w*, r*]))
+      where <is-list> r*
+      with  (xt', w*) := <transform-P-to-T-r> xt
+      
+  Desugar :
+      RDefP(f, xs, xt, Rule(a, b, r)) -> RDefT(f, xs, xt', Rule(a, b, [w*, WhereClause(r)]))
+      where <not(is-list)> r
+      with  (xt', w*) := <transform-P-to-T-r> xt
+            
+  // For a given term argument (except plain variables), returns a tuple (term, name).
+  transform-P-to-T-s(|s): xt -> (xt', s')
+  with  names := <map(add-name)> xt
+          ; xt' := <map(transform-term)> names
+          ; s' := <filter(match-term); seqs(|s)> names
+            
+  transform-P-to-T-r: xt -> (xt', w*)
+  with  names := <map(add-name)> xt
+          ; xt' := <map(transform-term)> names
+          ; w* := <filter(match-term-r)> names
+            
+  add-name: Var(n) -> (<id>, n)
+  add-name: _ -> (<id>, <new>)
+  transform-term: (_, n) -> DefaultVarDec(n)
+  match-term: (t, n) -> Where(Assign(t, Var(n))) where <not(?Var(_))>t
+  match-term-r: (t, n) -> WhereClause(Assign(t, Var(n))) where <not(?Var(_))>t
+  seqs(|s) = foldr(!s, MkSeq)
+
+  
+  
+  
 
 // dynamic rules
 
@@ -288,6 +333,8 @@ rules
 
   Desugar :
     RDec(f, ss) -> RDecT(f, ss, [])
+
+    	
 
 /**
  * Dynamic rules
@@ -344,6 +391,8 @@ rules
 
   Desugar :
     SDef(f, xs, s) -> SDefT(f, xs, [], s)
+  
+  // See also SDefP()
 
 // strategy calls
 

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/model/model.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/model/model.str
@@ -1,4 +1,4 @@
-module model
+module stratego/strc/model/model
 
 imports Stratego-Sugar
 
@@ -125,9 +125,11 @@ strategies
   m-def-signature =
     try(Desugar)
     ; (  \ SDefT(f, xs, ys, s)      -> (f, <length>xs, <length>ys) \
+      <+ \ SDefP(f, xs, ys, s)      -> (f, <length>xs, <length>ys) \
       <+ \ ExtSDef(f, xs, ys)       -> (f, <length>xs, <length>ys) \
       <+ \ ExtSDefInl(f, xs, ys, s) -> (f, <length>xs, <length>ys) \
       <+ \ RDefT(f, xs, ys, s)      -> (f, <length>xs, <length>ys) \
+      <+ \ RDefP(f, xs, ys, s)      -> (f, <length>xs, <length>ys) \
       <+ \ AnnoDef(a*, def)         -> <m-def-signature> def\)
 
   is-external =

--- a/strategoxt/stratego-libraries/strc/tests/test2/pattern-matching-term-parameters.str
+++ b/strategoxt/stratego-libraries/strc/tests/test2/pattern-matching-term-parameters.str
@@ -30,6 +30,9 @@ rules
 	// Matching with application
 	appl-s(|<id>) = !"r10"
 	
+	// Matching with application
+	appl-many-s(|<id>, <id>) = !"r18"
+	
 	// Multi-match
 	multi-match-s(|"x", "y") = !"r11"
 	multi-match-s(|"y", "z") = !"r12"
@@ -37,6 +40,11 @@ rules
 	// Fallthrough match
 	fallthrough-s(|"x")    = !"r16"
 	fallthrough-s(|x)      = !"r17"
+	
+	// One, two, many
+	to-english(|1) = !"one"
+	to-english(|2) = !"two"
+	to-english(|_) = !"many"
 
 strategies
 	
@@ -101,8 +109,12 @@ strategies
       annotations-stest;
       at-stest;
       appl-stest;
+	  appl-many-stest;
       multi-match-stest;
       fallthrough-stest;
+	  to-english-one-test;
+	  to-english-two-test;
+	  to-english-many-test;
       single-term-rtest;
       var-and-term-rtest;
       wildcard-rtest;
@@ -162,10 +174,17 @@ strategies
 	appl-stest = 
 	  	apply-test(!"appl-stest"
 		      ,appl-s(|"y")
-		      ,!"y"
+		      ,!()
 		      ,!"r10"
 		      )
-			  
+		      
+	appl-many-stest =
+	  	apply-test(!"appl-many-1-stest"
+		      ,appl-many-s(|"x", "y")
+		      ,!()
+		      ,!"r18"
+		      )
+		      
 	multi-match-stest = 
 	  	apply-test(!"multi-match-stest"
 		      ,multi-match-s(|"y", "z")
@@ -178,6 +197,27 @@ strategies
 		      ,fallthrough-s(|"q")
 		      ,!()
 		      ,!"r17"
+		      )
+		      
+	to-english-one-test = 
+	  	apply-test(!"to-english-one-test"
+		      ,to-english(|1)
+		      ,!()
+		      ,!"one"
+		      )
+		      
+	to-english-two-test = 
+	  	apply-test(!"to-english-two-test"
+		      ,to-english(|2)
+		      ,!()
+		      ,!"two"
+		      )
+		      
+	to-english-many-test = 
+	  	apply-test(!"to-english-many-test"
+		      ,to-english(|3)
+		      ,!()
+		      ,!"many"
 		      )
 			  
 	single-term-rtest = 

--- a/strategoxt/stratego-libraries/strc/tests/test2/pattern-matching-term-parameters.str
+++ b/strategoxt/stratego-libraries/strc/tests/test2/pattern-matching-term-parameters.str
@@ -1,16 +1,6 @@
 module pattern-matching-term-parameters
 
 imports libstratego-lib
-signature
-  constructors
-    True   : Exp
-    False  : Exp
-    Var    : String -> Exp
-
-    Assign : String * Exp -> Stat
-    Skip   : Stat
-    If     : Exp * Stat -> Stat
-    If     : Exp * Stat * Stat -> Stat
 
 rules
 	
@@ -275,3 +265,4 @@ strategies
 		      ,!()
 		      ,!"r17"
 		      )
+		      

--- a/strategoxt/stratego-libraries/strc/tests/test2/pattern-matching-term-parameters.str
+++ b/strategoxt/stratego-libraries/strc/tests/test2/pattern-matching-term-parameters.str
@@ -1,0 +1,277 @@
+module pattern-matching-term-parameters
+
+imports libstratego-lib
+signature
+  constructors
+    True   : Exp
+    False  : Exp
+    Var    : String -> Exp
+
+    Assign : String * Exp -> Stat
+    Skip   : Stat
+    If     : Exp * Stat -> Stat
+    If     : Exp * Stat * Stat -> Stat
+
+rules
+	
+	// Matching a single term
+	single-term-s(|"t1") = !"r1"
+	single-term-s(|"t2") = !"r2"
+	
+	// Matching a variable and a term
+	var-and-term-s(|x, "t1") = !x
+	var-and-term-s(|x, "t2") = !"r4"
+	
+	// Matching a wildcard
+	wildcard-s(|_) = !"r5"
+	
+	// Matching primitives
+	primitives-s(|1)   = !"r6"
+	primitives-s(|"1") = !"r7"
+	primitives-s(|1.0) = !"r8"
+	
+	// Matching with annotations
+	annotations-s(|"x"{"y"}) = !"r9"
+	annotations-s(|x{y}) = !y
+	
+	// Matching with @
+	at-s(|x@"x") = !x
+	
+	// Matching with application
+	appl-s(|<id>) = !"r10"
+	
+	// Multi-match
+	multi-match-s(|"x", "y") = !"r11"
+	multi-match-s(|"y", "z") = !"r12"
+	
+	// Fallthrough match
+	fallthrough-s(|"x")    = !"r16"
+	fallthrough-s(|x)      = !"r17"
+
+strategies
+	
+	// Matching a single term
+	single-term-r(|"t1"): _ -> "r1"
+	single-term-r(|"t2"): _ -> "r2"
+	
+	// Default match
+	rmatch1(|x): _ -> "r3"
+	
+	// Matching a variable and a term
+	var-and-term-r(|x, "t1"): _ -> x
+	var-and-term-r(|x, "t2"): _ -> "r4"
+	
+	// Matching a wildcard
+	wildcard-r(|_): _ -> "r5"
+	
+	// Matching primitives
+	primitives-r(|1):   _ -> "r6"
+	primitives-r(|"1"): _ -> "r7"
+	primitives-r(|1.0): _ -> "r8"
+	
+	// Matching with annotations
+	annotations-r(|"x"{"y"}): _ -> "r9"
+	annotations-r(|x{y}):     _ -> y
+	
+	// Matching with @
+	at-r(|x@"x"): _ -> x
+	
+	// Matching with application
+	appl-r(|<id>): _ -> "r10"
+	
+	// Multi-match
+	multi-match-r(|"x", "y"): _ -> "r11"
+	multi-match-r(|"y", "z"): _ -> "r12"
+	
+	// Match with where clause
+	where-clause-r(|"x"): _ -> r
+	where r := "r13"
+	
+	// Match with with clause
+	with-clause-r(|"x"): _ -> r
+	with r := "r14"
+	
+	// Match with where/with clauses
+	where-with-clauses-r(|"x"): _ -> r'
+	where r := "r15"
+	with  r' := r
+	
+	// Fallthrough match
+	fallthrough-r(|"x"): _ -> "r16"
+	fallthrough-r(|x):   _ -> "r17"
+
+strategies
+
+  main = 
+    test-suite(!"pattern-matching-term-parameters",
+      single-term-stest;
+      var-and-term-stest;
+      wildcard-stest;
+      primitives-stest;
+      annotations-stest;
+      at-stest;
+      appl-stest;
+      multi-match-stest;
+      fallthrough-stest;
+      single-term-rtest;
+      var-and-term-rtest;
+      wildcard-rtest;
+      primitives-rtest;
+      annotations-rtest;
+      at-rtest;
+      appl-rtest;
+      multi-match-rtest;
+      where-clause-rtest;
+      with-clause-rtest;
+      where-with-clauses-rtest;
+      fallthrough-rtest
+    )
+			      
+	single-term-stest = 
+	  	apply-test(!"single-term-stest"
+		      ,single-term-s(|"t2")
+		      ,!()
+		      ,!"r2"
+		      )
+			  
+	var-and-term-stest = 
+	  	apply-test(!"var-and-term-stest"
+		      ,var-and-term-s(|"x", "t1")
+		      ,!()
+		      ,!"x"
+		      )
+			  
+	wildcard-stest = 
+	  	apply-test(!"wildcard-stest"
+		      ,wildcard-s(|"t2")
+		      ,!()
+		      ,!"r5"
+		      )
+	
+	primitives-stest = 
+	  	apply-test(!"primitives-stest"
+		      ,primitives-s(|1.0)
+		      ,!()
+		      ,!"r8"
+		      )
+	
+	annotations-stest = 
+	  	apply-test(!"annotations-stest"
+		      ,annotations-s(|"y"{"z"})
+		      ,!()
+		      ,!"z"
+		      )
+	
+	at-stest = 
+	  	apply-test(!"at-stest"
+		      ,at-s(|"x")
+		      ,!()
+		      ,!"x"
+		      )
+	
+	appl-stest = 
+	  	apply-test(!"appl-stest"
+		      ,appl-s(|"y")
+		      ,!"y"
+		      ,!"r10"
+		      )
+			  
+	multi-match-stest = 
+	  	apply-test(!"multi-match-stest"
+		      ,multi-match-s(|"y", "z")
+		      ,!()
+		      ,!"r12"
+		      )
+	
+	fallthrough-stest = 
+	  	apply-test(!"fallthrough-stest"
+		      ,fallthrough-s(|"q")
+		      ,!()
+		      ,!"r17"
+		      )
+			  
+	single-term-rtest = 
+	  	apply-test(!"single-term-rtest"
+		      ,single-term-r(|"t2")
+		      ,!()
+		      ,!"r2"
+		      )
+			  
+	var-and-term-rtest = 
+	  	apply-test(!"var-and-term-rtest"
+		      ,var-and-term-r(|"x", "t1")
+		      ,!()
+		      ,!"x"
+		      )
+			  
+	wildcard-rtest = 
+	  	apply-test(!"wildcard-rtest"
+		      ,wildcard-r(|"t2")
+		      ,!()
+		      ,!"r5"
+		      )
+	
+	primitives-rtest = 
+	  	apply-test(!"primitives-rtest"
+		      ,primitives-r(|1.0)
+		      ,!()
+		      ,!"r8"
+		      )
+	
+	annotations-rtest = 
+	  	apply-test(!"annotations-rtest"
+		      ,annotations-r(|"y"{"z"})
+		      ,!()
+		      ,!"z"
+		      )
+	
+	at-rtest = 
+	  	apply-test(!"at-rtest"
+		      ,at-r(|"x")
+		      ,!()
+		      ,!"x"
+		      )
+	
+	appl-rtest = 
+	  	apply-test(!"appl-rtest"
+		      ,appl-r(|"y")
+		      ,!"y"
+		      ,!"r10"
+		      )
+	
+	multi-match-rtest = 
+	  	apply-test(!"multi-match-rtest"
+		      ,multi-match-r(|"y", "z")
+		      ,!()
+		      ,!"r12"
+		      )
+	
+	where-clause-rtest = 
+	  	apply-test(!"where-clause-rtest"
+		      ,where-clause-r(|"x")
+		      ,!()
+		      ,!"r13"
+		      )
+			  
+	with-clause-rtest = 
+	  	apply-test(!"with-clause-rtest"
+		      ,with-clause-r(|"x")
+		      ,!()
+		      ,!"r14"
+		      )
+			  
+	
+	where-with-clauses-rtest = 
+	  	apply-test(!"where-with-clauses-rtest"
+		      ,where-with-clauses-r(|"x")
+		      ,!()
+		      ,!"r15"
+		      )
+			  
+	
+	fallthrough-rtest = 
+	  	apply-test(!"fallthrough-rtest"
+		      ,fallthrough-r(|"q")
+		      ,!()
+		      ,!"r17"
+		      )

--- a/strategoxt/syntax/stratego-front/syn/Stratego-Sugar-Rules.sdf
+++ b/strategoxt/syntax/stratego-front/syn/Stratego-Sugar-Rules.sdf
@@ -12,6 +12,10 @@ exports
 
     Id "(" {Typedid ","}* 
        "|" {Typedid ","}* ")" ":" Rule 		-> RuleDef {cons("RDefT")}
+       
+    %% Rule definition with pattern matched term parameters
+    Id "(" {Typedid ","}* 
+       "|" {Term ","}* ")" ":" Rule 		-> RuleDef {cons("RDefP"), avoid}
 
   sorts Rule RuleCond
   context-free syntax

--- a/strategoxt/syntax/stratego-front/syn/Stratego-Sugar-Strategies.sdf
+++ b/strategoxt/syntax/stratego-front/syn/Stratego-Sugar-Strategies.sdf
@@ -10,6 +10,9 @@ exports
     Id  		      "=" Strategy -> StrategyDef {cons("SDefNoArgs")}
     Id "(" {Typedid ","}* ")" "=" Strategy -> StrategyDef {cons("SDef")}
 
+    %% Strategy definition with pattern matched term parameters
+    Id "(" {Typedid ","}* "|" {Term ","}* ")" "=" Strategy -> StrategyDef {cons("SDefP"), avoid}
+
   context-free syntax
     ID 				  	  -> Typedid {cons("DefaultVarDec")}
 


### PR DESCRIPTION
Term parameters in strategies and rules can now do pattern matching.The syntax is as follows:

> You can specify any term as a term parameter to a strategy or rule, not just variables. You can mix-and-match term variables with term patterns:
> 
>      mystrategy(|"exact", v) = !v
>
> Use a wildcard if you don't care about the value:
>
>      mystrategy(|_) = !()
>
> The syntax works for both rules and strategies:
>
>      myrule(|"exact"): x -> x
>
> Strategy application is supported:
>
>      mystrategy(|<newname> "a") = !()
>
> ...also without a term:
>
>      myrule(|<id>): _ -> ()
>

As an example, a switch-case using strategies:

	to-english(|1) = !"one"
	to-english(|2) = !"two"
	to-english(|_) = !"many"

This features was proposed by Daco Harkes and implemented by Daco Harkes and Daniël Pelsmaeker. See [StrategoXT#907](http://yellowgrass.org/issue/StrategoXT/907) for more information.