### PR TITLE
Added recovery (logging a warning) when parse result cannot be cached…

### DIFF
--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/parse/parse-stratego.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/parse/parse-stratego.str
@@ -224,7 +224,7 @@ strategies
           ; ast := <ReadFromFile> cache-path
         <+
             ast := <parse> path
-          ; <WriteToBinaryFile> (cache-path, ast)
+          ; <WriteToBinaryFile <+ log(|Warning(), <concat-strings>["Unable to cache parse result to ", cache-path])> (cache-path, ast)
         )
       else
         ast := <parse>


### PR DESCRIPTION
…. This can happen with very long file names