### PR TITLE
Preserve names in stratego compiler

### DIFF
--- a/strategoxt/stratego-libraries/lib/spec/strategy/general/rename.str
+++ b/strategoxt/stratego-libraries/lib/spec/strategy/general/rename.str
@@ -112,3 +112,23 @@ strategies
                     <+ RnBinding(bndvars, paste);
                        DistBinding(x, boundin)))
 
+rules
+
+  RnBinding(bndvrs, paste : (term -> vars) * term -> term, newvar : term -> term) :
+    (t, env1) -> (<paste(!ys)> t, env1, env2)
+    where <bndvrs> t => xs; map(newvar) => ys; 
+          <conc>(<zip(id)>(xs,ys), env1) => env2
+
+strategies
+
+  rename(isvar : (name -> env) * name -> term
+        , bndvars
+        , boundin : (term -> term) * (term -> term) * (term -> term) * term -> term
+        , paste : (term -> vars) * term -> term
+        , newvar : term -> term
+        )
+  = \ t -> (t, []) \ ;
+    rec x(env-alltd(RnVar(isvar)
+                    <+ RnBinding(bndvars, paste, newvar);
+                       DistBinding(x, boundin)))
+

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/c/frame-composition.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/c/frame-composition.str
@@ -89,7 +89,7 @@ strategies
    */
 
   new-scoped-counter =
-    new; reset-scoped-counter(|<id>)
+    <newname> "scoped_counter"; reset-scoped-counter(|<id>)
 
   reset-scoped-counter(|c) =
     set-scoped-counter(|c,0)

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/desugar.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/desugar.str
@@ -95,7 +95,8 @@ rules // Lift non-variable arguments to primitives.
 
   LiftPrimArg :
     t -> ([x], (Where(Seq(Build(t), Match(Var(x)))), Var(x)))
-    where <not(Var(id))> t; new => x
+    where <not(Var(id))> t
+        ; x := <newname> "prim_arg_m"
 
 
 /*
@@ -124,12 +125,12 @@ rules
 
   LiftBuildApp :
     Term|[ <s> t ]| -> Term|[ x ]|
-    where new => x
+    where x := <newname> "lift_app_in_build_m"
         ; rules( AddApp :+ s' -> |[ {x : where(<s> t => x); s'} ]| )
 
   LiftBuildApp :
     Term|[ <s> ]| -> Term|[ x ]|
-    where new => x
+    where x := <newname> "lift_app_in_build_m"
         ; rules( AddApp :+ s' -> |[ {x : where(s => x); s'} ]| )
 
   LiftTopLevelMatchApp :
@@ -144,12 +145,12 @@ rules
 
   LiftMatchApp :
     Term|[ <s> t ]| -> Term|[ x ]|
-    where new => x
+    where x := <newname> "lift_app_in_match_m"
         ; rules( AddApp :+ s' -> |[ {x : s'; !x; !t; s} ]| )
 
   LiftMatchApp :
     Term|[ <s> ]| -> Term|[ x ]|
-    where new => x
+    where x := <newname> "lift_app_in_match_m"
         ; rules( AddApp :+ s' -> |[ {x : s'; !x; s} ]| )
 
 strategies
@@ -190,8 +191,8 @@ rules
   CtoS(name) : [WithClause(s)  | cond*] -> Seq(with,      <CtoS(name)> cond*)
     where
       sname := <name>
-    ; x := <new>
-    ; y := <new>
+    ; x := <newname> "unused"
+    ; y := <newname> "unused"
     ; with := <with-strategy> (s,sname)
       <+ with := With(s) // <name> failed
 
@@ -215,7 +216,7 @@ strategies // "with" strategy
   Desugar:
     With(s) -> <with-strategy> (s,sname)
     where
-      x := <new>
+      x := <newname> "unused"
       ; ( sname := <WithContext>
         <+sname := ""
         )
@@ -317,7 +318,7 @@ rules
           ; w* := <filter(match-term-r)> names
             
   add-name: Var(n) -> (<id>, n)
-  add-name: _ -> (<id>, <new>)
+  add-name: _ -> (<id>, <get-constructor;snewvar>)
   transform-term: (_, n) -> DefaultVarDec(n)
   match-term: (t, n) -> Where(Assign(t, Var(n))) where <not(?Var(_))>t
   match-term-r: (t, n) -> WhereClause(Assign(t, Var(n))) where <not(?Var(_))>t
@@ -451,7 +452,7 @@ rules
   Desugar :
     SwitchChoice(s1, sc*, s2) -> |[ {x : where(s1 => x); s} ]|
     // |[ switch s1 sc* s2 end ]| -> |[ {x : where(s1 => x); s} ]|
-    where new => x
+    where x := <newname> "switch"
         ; <foldr(!s2, glchoice(|x))> sc* => s
 
   glchoice(|x) : 
@@ -463,7 +464,7 @@ rules
   Desugar :
     |[ where(s) ]| -> |[ {x: ?x; s; !x} ]|
     where <not(Id)> s
-    with x := <new>
+    with x := <newname> "where"
 
   Desugar :
     |[ where(id) ]| -> |[ id ]|
@@ -500,7 +501,10 @@ rules
   Desugar :
     ExplodeCong(s1, s2) -> 
     |[ {x, x', y, y': (x#(y) -> x'#(y') where <s1> x => x'; <s2> y => y')} ]|
-    where new => x; new => x'; new => y; new => y'
+    where x := <newname> "expl_cong_cons_m"
+        ; x' := <newname> "expl_cong_args_m"
+        ; y := <newname> "expl_cong_cons_b"
+        ; y' := <newname> "expl_cong_args_b"
 
   Desugar :
     ListCongNoTail(ts) -> <foldr(!|[ ?[] ]|, DesugarConsArgs)> ts
@@ -518,7 +522,11 @@ rules
        ![x' | y']{^z}
       }
     ]|
-    where new => x; new => y; new => x'; new => y'; new => z
+    where x := <newname> "list_cong_head_m"
+        ; y := <newname> "list_cong_tail_m"
+        ; x' := <newname> "list_cong_head_b"
+        ; y' := <newname> "list_cong_tail_b"
+        ; z := <newname> "list_cong_annos"
 
   Desugar :
     StrCong(x) -> Match(NoAnnoList(Str(x)))

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/introduce-congdefs.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/introduce-congdefs.str
@@ -95,7 +95,7 @@ rules
     where <length> ts => n
         ; <not(CongDefined)> (f, n)
         ; rules(CongDefined : (f, n) -> ())
-        ; <unzip(new; !(VarDec(<id>, DefaultStrat()), <id>))> ts => (xdecs, xs)
+        ; <unzip(<newname> "cong_arg"; !(VarDec(<id>, DefaultStrat()), <id>))> ts => (xdecs, xs)
 
   MkCongDefs : 
     Constructors(ods) -> <filter(MkCongDef)> ods
@@ -111,7 +111,7 @@ strategies
     SDefT(f, xdecs, [], Cong(f, <map(MkCall)> xs))
     where <length> ts => n
         ; <not(ModDefinition)> (f, n, 0)
-        ; <unzip(new; !(VarDec(<id>, DefaultStrat()), <id>))> ts => (xdecs, xs)
+        ; <unzip(<newname> "cong_arg"; !(VarDec(<id>, DefaultStrat()), <id>))> ts => (xdecs, xs)
 
 strategies
 
@@ -120,7 +120,14 @@ strategies
   // Congruence over annotation
 
   AnnoCongDef =
-    where(new => f1; new => f2; new => x1; new => x2; new => y1; new => y2)
+    where(
+        f1 := <newname> "anno_cong_str_arg1_"
+      ; f2 := <newname> "anno_cong_str_arg2_"
+      ; x1 := <newname> "anno_cong_term_m"
+      ; x2 := <newname> "anno_cong_anno_m"
+      ; y1 := <newname> "anno_cong_term_b"
+      ; y2 := <newname> "anno_cong_anno_b"
+    )
     ; !|[ Anno_Cong__(f1 : ATerm -> ATerm, f2 : ATerm -> ATerm|) =
             {x1, x2, y1, y2 :
              ?x1{^x2}

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/lift-dynamic-rules.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/lift-dynamic-rules.str
@@ -202,12 +202,12 @@ strategies
   DesugarDynRuleDef :
     |[ rules( f(a1*|a2*) : t  ) ]| -> 
     |[ rules( f(a1*|a2*) : t' -> t' where id ) ]|
-    where <alltd(\ Wld() -> Var(<new>) \ )> t => t'
+    where <alltd(\ Wld() -> Var(<newname> "wld") \ )> t => t'
 
   DesugarDynRuleDef :
     |[ rules( f(a1*|a2*).t1 : t2 ) ]| -> 
     |[ rules( f(a1*|a2*).t1 : t2' -> t2' where id ) ]|
-    where <alltd(\ Wld() -> Var(<new>) \ )> t2 => t2'
+    where <alltd(\ Wld() -> Var(<newname> "wld") \ )> t2 => t2'
 
   // Dependent dynamic rules
 
@@ -237,8 +237,13 @@ strategies
                  })
          )
     ]|
-    where new => x; new => x1; new => x2
-        ; new => y0; new => y1; new => y2; new => z
+    where x := <newname> "dyn_rule_def"
+        ; x1 := <newname> "dyn_rule_def"
+        ; x2 := <newname> "dyn_rule_def"
+        ; y0 := <newname> "dyn_rule_def"
+        ; y1 := <newname> "dyn_rule_def"
+        ; y2 := <newname> "dyn_rule_def"
+        ; z := <newname> "dyn_rule_def"
         ; <dummify> t2 => t2'
         ; create-new-strategy(|f)
         ; create-undefine-strategy(|f)
@@ -331,7 +336,7 @@ rules
   /**
    * Split a dynamic rule into a call to assert which records a mapping
    * from the left-hand side of the rule instantiated with the bindings to
-   * context variables to the set of bindings to the context variales not
+   * context variables to the set of bindings to the context variables not
    * occurring in the left-hand side.
    * 
    * Notes:
@@ -358,7 +363,7 @@ rules
 
         ; <create-aux-rule(|stdrule)> drd
 
-        ; new => x
+        ; x := <newname> "dyn_rule_where"
         ; <aux-call(|x)> drd => aux-call
         ; <lookup-key(|x)> t1 => t3
         ; <dr-rename-vars> t3 => stdkey
@@ -472,12 +477,12 @@ strategies
     ; if is-new(|f, g, stdrule) then
         <get-stamp> stdrule => stamp
         ; <closure> drd => t*
-        ; new => x // holding entire lhs
+        ; x := <newname> "dyn_rule_aux" // holding entire lhs
         ; <tvars; map(!DefaultVarDec(<id>))> t1 => a3* // variables in lhs
         ; if AssumeSharedTerms => 1 then
             a3'* := a3*
           else
-            a3'* := <map(DefaultVarDec({ a: ?a; if <one(Var(?a))> t* then new end }))> a3* // ignore lhs vars
+            a3'* := <map(DefaultVarDec({ a: ?a; if <one(Var(?a))> t* then <newname> "dyn_rule_aux_v" end }))> a3* // ignore lhs vars
           end
         ; add-def(||[ 
             g(a1*|a2*, a3'*, x) : (~str:stamp, t*) -> t2 where <s> x 
@@ -612,7 +617,7 @@ strategies
     ; <concat-strings> [chain, "-", f] => g
     ; if is-new(|f, g, stdkey); try(is-new(|f, g, ())) then
         where(
-          new => y
+          y := <newname> "dyn_chain_rule"
           ; <aux-call(|y)> drd => s1
           ; <tvars> t1 => x*
         )
@@ -651,7 +656,7 @@ strategies
     ; <concat-strings> [fold, "-", f] => g
     ; if is-new(|f, g, stdkey); try(is-new(|f, g, ())) then
         where(
-          new => y
+          y := <newname> "dyn_fold_rule"
           ; <aux-call(|y)> drd => s1
           ; <tvars> t1 => x*
           ; y' := <newname> "fold"
@@ -677,7 +682,7 @@ strategies
           g1(a1*|a2*) =
             dr-break(|~str:f)
         ]|)
-        ; new => x1
+        ; x1 := <newname> "dyn_break_rule"
         ; add-def(||[
             g2(a1*|a2*, x1) =
               dr-break(|~str:f, x1)
@@ -702,7 +707,7 @@ strategies
           g1(a1*|a2*) =
             dr-continue(|~str:f)
         ]|)
-        ; new => x1
+        ; x1 := <newname> "dyn_cont_rule"
         ; add-def(||[
             g2(a1*|a2*, x1) =
               dr-continue(|~str:f, x1)
@@ -713,8 +718,8 @@ strategies
     ?drd@|[ rules( f(a1*|a2*) : t1 -> t2 where s2 ) ]|
     ; _throw(|f) => g
     ; if is-new(|f, g, stdkey); try(is-new(|f, g, ())) then
-        new => x1
-        ; new => x2
+        x1 := <newname> "dyn_throw_rule1_"
+        ; x2 := <newname> "dyn_throw_rule2_"
         ; add-def(||[
             g(a1*, x1 | a2*, x2) =
               dr-throw(x1 | x2, ~str:f)
@@ -734,7 +739,7 @@ strategies
   create-innermost-scope-strategy(|f) =
     _innermost-scope(|f) => g
     ; if is-new(|f, g, ()) then
-        new => x
+        x := <newname> "dyn_inn_scope"
         ; add-def(||[ g(x|) = dr-get-first-scope-label(x| ~str:f) ]|)
       end
 

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/needed-defs.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/front/needed-defs.str
@@ -170,11 +170,14 @@ rules
 
   JoinDefs2 : 
     defs @ [SDefT(f, xs1, xs2, s) | _] -> SDefT(f, ys1, ys2, <choices> ss)
-    where <map(VarDec(new,id))> xs1 => ys1
-	; <map(VarDec(new,id))> xs2 => ys2
+    where <map(VarDec(NewID,id))> xs1 => ys1
+	; <map(VarDec(NewID,id))> xs2 => ys2
 	; <map(\ VarDec(y, t) -> SVar(y) \ )> ys1 => ys1'
 	; <map(\ VarDec(y, t) -> Var(y) \ )> ys2 => ys2'
 	; <map(RenameDefinition(|ys1', ys2'))> defs => ss
+
+  NewID: ListVar(x) -> <tnewvar> x
+  NewID = is-string;tnewvar
 
   RenameDefinition(|ys1, ys2) :
     SDefT(_, xs1, xs2, s1) -> s3

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/lib/stratlib.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/lib/stratlib.str
@@ -166,6 +166,12 @@ strategies
 
 strategies
 
+  tnewvar =
+    lower-case ; string-replace(|"-","_") ; string-replace(|"'","q") ; string-replace(|"*","s") ; newname <+ new
+
+  snewvar =
+    lower-case ; string-replace(|"-","_") ; string-replace(|"'","q") ; newname <+ new
+
   declared-vars =
     map(?VarDec(<id>,_) + ?DefaultVarDec(<id>))
 
@@ -176,10 +182,10 @@ strategies
     free-vars(Add2, Bind1 + Bind2 + Bind3 + Bind5 + Bind7 + Bind9, sboundin)
 
   trename = 
-    rename(Var, Bind0 + Bind6 + Bind8 + Bind10, tboundin, tpaste)
+    rename(Var, Bind0 + Bind6 + Bind8 + Bind10, tboundin, tpaste, tnewvar)
 
   srename = 
-    rename(SVar, Bind1 + Bind2 + Bind3 + Bind5 + Bind7 + Bind9, sboundin, spaste)
+    rename(SVar, Bind1 + Bind2 + Bind3 + Bind5 + Bind7 + Bind9, sboundin, spaste, snewvar)
 
   svars-arity = 
     free-vars2(\CallT(SVar(f), as1, as2) -> [(f, (<length> as1, <length> as2))]\
@@ -198,3 +204,23 @@ strategies
 
   ssubs = 
     substitute(IsSVar)
+
+rules
+
+  RnBinding(bndvrs, paste : (term -> vars) * term -> term, newvar : term -> term) :
+    (t, env1) -> (<paste(!ys)> t, env1, env2)
+    where <bndvrs> t => xs; map(newvar) => ys;
+          <conc>(<zip(id)>(xs,ys), env1) => env2
+
+strategies
+
+  rename(isvar : (name -> env) * name -> term
+        , bndvars
+        , boundin : (term -> term) * (term -> term) * (term -> term) * term -> term
+        , paste : (term -> vars) * term -> term
+        , newvar : term -> term
+        )
+  = \ t -> (t, []) \ ;
+    rec x(env-alltd(RnVar(isvar)
+                    <+ RnBinding(bndvars, paste, newvar);
+                       DistBinding(x, boundin)))

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/match/linearize.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/match/linearize.str
@@ -2,6 +2,7 @@
 
 module linearize
 imports Stratego
+	stratego/strc/lib/stratlib
 
 strategies
 
@@ -32,4 +33,4 @@ rules
   OldVar: 
     Pair(Var(x), (xs, ys, ts)) -> 
     Pair(Var(x), (xs, [y | ys], Seq(Assign(Var(x), Var(y)), ts)))
-    where <is-subterm> (x, xs); new => y
+    where <is-subterm> (x, xs); y := <conc-strings;tnewvar> ("linear_", x)

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/match/match-to-matrix.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/match/match-to-matrix.str
@@ -34,7 +34,7 @@ rules
 
   ExpandId :
     Id() -> Scope([x], Seq(Match(Var(x)), Build(Var(x))))
-    where new => x
+    where x := <newname> "id_strat"
 
   MatchToMatrix : 
     Match(t) -> <term-to-matrix> t

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/match/matrix-to-dfa.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/match/matrix-to-dfa.str
@@ -42,7 +42,8 @@ rules
   RowLet(|ps) :
     Row(ts1, s) -> 
     ([SDefT(f, [], as, s)], Row([], ts1, CallT(SVar(f), [], ts2)))
-    where <not(simple-strategy)> s; new => f
+    where <not(simple-strategy)> s
+        ; f := <newname> "row_let"
         //; <debug(!"RowLet: ")> Row(ts1, s)
         ; < tvars-matrix
           ; <isect>(<id>, ps)
@@ -136,7 +137,7 @@ rules
 	//; debug(!"d: ")
 	; <default-state> rows => def
 	//; debug(!"e: ")
-	; new => label
+	; label := <newname> "mixture"
 	//; debug(!"f: ")
 	; rules(MatrixSeenBefore : Matrix(rows) -> Continue(label))
 

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/build-match-laws.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/build-match-laws.str
@@ -125,11 +125,11 @@ rules // other rules
 
   WhereSavesCurrentTerm :
     Where(s) -> Scope([x], Seq(Match(Var(x)), Seq(s, Build(Var(x)))))
-    where new => x
+    where x := <newname> "where"
 
   TestSavesCurrentTerm :
     Test(s) -> Scope([x], Seq(Match(Var(x)), Seq(s, Build(Var(x)))))
-    where new => x
+    where x := <newname> "test"
 
 rules
 

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/canonicalize.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/canonicalize.str
@@ -39,7 +39,7 @@ rules
 
   CreateDef2 :
     s -> (CallT(SVar(f),[],[]), [SDefT(f,[],[],s)])
-    where new => f
+    where f := <newname> "canon_arg"
 
   Canon :
     CallT(f, args1, args2) -> CallT(f, args1', args2)

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/congruence-laws.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/congruence-laws.str
@@ -21,8 +21,11 @@ rules
           Seq(Match(Anno(Op(f, xs'), Var(a))),
           Seq(<seqs> ss',
               Build(Anno(Op(f, ys'), Var(a))))))
-    where <map(new)> ss => xs; <map(!Var(<id>))> xs => xs'; new => a;
-	  <map(new)> ss => ys; <map(!Var(<id>))> ys => ys';
+    where <map(<newname> "trans_cong")> ss => xs
+        ; <map(!Var(<id>))> xs => xs'
+        ; a := <newname> "trans_cong"
+        ; <map(<newname> "trans_cong")> ss => ys
+        ; <map(!Var(<id>))> ys => ys';
           <zip(\ ((x,y), s) -> 
 	         Seq(Build(Var(x)), 
 		 Seq(s, Match(Var(y)))) \ )> (<zip(id)>(xs,ys), ss) => ss'
@@ -33,8 +36,8 @@ rules
           Seq(Match(Anno(Op(f, xs'), Var(a))),
           Seq(<seqs> ss',
               Build(Anno(Op(f, ys'), Var(b))))))
-    where <map(new)> [s | ss] => [a | xs]; map(!Var(<id>)) => xs';
-	  <map(new)> [s | ss] => [b | ys]; map(!Var(<id>)) => ys';
+    where <map(<newname> "trans_cong")> [s | ss] => [a | xs]; map(!Var(<id>)) => xs';
+	  <map(<newname> "trans_cong")> [s | ss] => [b | ys]; map(!Var(<id>)) => ys';
           <zip(\ ((x,y), s) -> Seq(Build(Var(x)), Seq(s, Match(Var(y)))) \ )> 
             (<zip(id)>(xs,ys), [s | ss]) => ss'
 
@@ -50,5 +53,6 @@ rules
 
   ApplyStrat : 
     s -> ((x,y),Seq(Build(Var(x)), Seq(s, Match(Var(y)))))
-    where new => x; new => y
+    where x := <newname> "apply_b"
+        ; y := <newname> "apply_m"
 */

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/fusion.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/fusion.str
@@ -58,7 +58,7 @@ strategies
     ?|[ innermost_1_0(s1|) ]| 
     ; log(|Notice(),"Application of innermost found")
 
-    ; where(new => x)
+    ; where(x := <newname> "inn_fusion")
     ; where(<seq-over-choice> Strategy|[ bottomup_1_0(x(|)|) ]|)
     ; where(<bottomup-to-var> Strategy|[ bottomup_1_0(x(|)|) ]|)
 
@@ -181,8 +181,8 @@ strategies // outermost fusion
     |[ outermost_1_0(s1|) ]| -> 
     |[ let f = repeat(rec x(s2 <+ s3)); all(f) in f end ]|
     where log(|Notice(),"Application of outermost found")
-	; new => x
-	; new => f
+	; x := <newname> "out_fusion_rec"
+	; f := <newname> "out_fusion_str"
 	; <inline-rules> s1 => s2
         ; derive-hnf-traversal(|x) => s3
 

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/worker-wrapper.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/opt/worker-wrapper.str
@@ -17,7 +17,7 @@ strategies
       ; <diff> (x*, x1*) => x2*
       ; <map(!VarDec(<id>, ConstType(Sort("ATerm", []))))> x1* => a3*
       ; <conc>(a2*, a3*) => a4*
-      ; new => g
+      ; g := <newname> "worker_wrapper"
       ; <map(\ VarDec(x, _) -> CallT(SVar(x),[],[]) \ )> a1* => s*
       ; <map(\ VarDec(x, _) -> Var(x) \ )> a4* => t*
      


### PR DESCRIPTION
The following changes give name hints to names generated by the compiler and rename variables from the source code in a way that they are still recognisable. This helps to make stack traces from Stratego a lot more readable because we no longer lose a lot of strategy names to the aggressive renaming of the compiler. 