### PR TITLE
Build spoofax-libs.jar with Maven

### DIFF
--- a/strategoxt/stratego-libraries/spoofax-libs-pom.xml
+++ b/strategoxt/stratego-libraries/spoofax-libs-pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spoofax-libs</artifactId>
+	<packaging>jar</packaging>
+	<description>Strategoxt spoofax-libs generation</description>
+
+	<parent>
+		<groupId>org.metaborg</groupId>
+		<artifactId>parent.java</artifactId>
+		<version>2.5.0-SNAPSHOT</version>
+		<relativePath>../../releng/parent/java</relativePath>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.metaborg</groupId>
+			<artifactId>org.spoofax.interpreter.core</artifactId>
+			<version>${metaborg-version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.metaborg</groupId>
+			<artifactId>strategoxt-min-jar</artifactId>
+			<version>${metaborg-version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.metaborg</groupId>
+			<artifactId>org.spoofax.interpreter.library.xml</artifactId>
+			<version>${metaborg-version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.metaborg</groupId>
+			<artifactId>org.spoofax.interpreter.library.java</artifactId>
+			<version>${metaborg-version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.metaborg</groupId>
+			<artifactId>org.spoofax.interpreter.library.jsglr</artifactId>
+			<version>${metaborg-version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.metaborg</groupId>
+			<artifactId>org.spoofax.interpreter.library.index</artifactId>
+			<version>${metaborg-version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.metaborg</groupId>
+			<artifactId>org.metaborg.runtime.task</artifactId>
+			<version>${metaborg-version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<skipTests>true</skipTests>
+				</configuration>
+			</plugin>
+			<plugin>
+				<!-- This assembles the jar that strategoxt uses in its build, there called spoofax-libs.jar -->
+				<artifactId>maven-assembly-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<developers>
+		<developer>
+			<name>Jeff Smits</name>
+			<email>j.smits-1@tudelft.nl</email>
+			<organization>Delft University of Technology</organization>
+			<organizationUrl>http://www.ewi.tudelft.nl/en</organizationUrl>
+		</developer>
+	</developers>
+</project>


### PR DESCRIPTION
I've manually compared the generated `target/spoofax-libs-2.5.0-SNAPSHOT-jar-with-dependencies.jar` with `java-backend/java/spoofax-libs.jar` and apart from a few extra things (`META-INF` directory and jsglr dependencies) everything seems to be the same. A bootstrap build of Stratego/XT with the newly generated jar also works. 
Adding @Gohla as reviewer since he knows most about Maven, and might want to integrate this into the Stratego/XT build. 