### PR TITLE
Update common.str

### DIFF
--- a/strategoxt/stratego-libraries/lib/spec/collection/list/common.str
+++ b/strategoxt/stratego-libraries/lib/spec/collection/list/common.str
@@ -157,8 +157,10 @@ strategies
 
   /**
    * Return first list element for which s succeeds.
+   * The result is the application of s to this element.
    *
-   * @type  List(a) -> a
+   * @param a -> b
+   * @type  List(a) -> b
    * @inc   fetch-elem-test
    */
   fetch-elem(s) = 


### PR DESCRIPTION
This PR makes the documentation a bit more precise. Note that the semantics of `fetch-elem(s)` and `getfirst(s)` are identical. Maybe the author intended to implement `fetch-elem(s)` the way it is documented, but changing the implementation would be irresponsible, so I've changed the documentation to reflect the implementation.