### PR TITLE
Add local-newname and friends to standard library

### DIFF
--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -55,7 +55,7 @@ strategies
   local-newname: prefix -> $[[prefix][number]]
   where number := <LocalNew <+ !0> prefix
       ; number' := <int-add(|1)> number
-      ; rules(LocalNew: s -> number')
+      ; rules(LocalNew: prefix -> number')
 
   /**
    * Generates a locally unique new string of the form 'c_d',

--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -85,9 +85,13 @@ strategies
    * overlapping names within the same scope-local-new call.
    */
   local-new =
+    // use LocalNewAlpha to shift from ASCII character a to some letter in the alphabet
     ![<int-add(|<LocalNewAlpha>)> 'a', '_']
+    // Update LocalNewAlpha with increment modulo 26
   ; where(LocalNewAlpha; int-add(|1); if int-gt(|25) then !0 end; ?alpha; rules(LocalNewAlpha := alpha))
+    // implode the letter + underscore list of characters to a string
   ; implode-string
+    // apply local-newname to share information and not produce overlapping names between the two
   ; local-newname
 
   /**

--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -100,7 +100,7 @@ strategies
    * This version of local-new uses the given context term as a "reentrant scope".
    * When given the same context term (within the same `scope-local-new` call), new locally unique
    * names are generated, but with a different context term the counter resets. The default context
-   * used by `local-newname`/0 is `()`. 
+   * used by `local-new`/0 is `()`. 
    */
   local-new(|context) =
     // use LocalNewAlpha to shift from ASCII character a to some letter in the alphabet

--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -28,7 +28,7 @@ strategies
 
   /**
    * Generates a locally unique new string with user-defined prefix
-   * the form 'sd', where s is a string and d is a positive integer.
+   * the form 's_d', where s is a string and d is a positive integer.
    * The produced string is *only* unique within the scope of
    * scope-local-new, and only based on previous calls to
    * local-newname/local-new. If you constructed a similar name by
@@ -40,17 +40,17 @@ strategies
    *
    * Examples (results are shown in comment)
    *   scope-local-new(
-   *     <local-newname; debug> "a"        // produces "a0"
-   *   ; <local-newname; debug> "a"        // produces "a1"
-   *   ; <local-newname; debug> "A"        // produces "A2"
-   *   ; <local-newname; debug> "b"        // produces "b0"
-   *   ; <local-newname; debug> "b"        // produces "b1"
-   *   ; <local-newname; debug> "b_2"      // produces "b_20"
-   *   ; <local-newname; debug> "b_2"      // produces "b_21"
-   *   ; <local-newname; debug> "b_a"      // produces "b_a0"
-   *   ; <local-newname; debug> "b_a"      // produces "b_a1"
-   *   ; <local-newname; debug> "a_"       // produces "a_0"
-   *   ; <local-newname; debug> "a_1"      // produces "a_10"
+   *     <local-newname; debug> "a"        // produces "a_0"
+   *   ; <local-newname; debug> "a"        // produces "a_1"
+   *   ; <local-newname; debug> "A"        // produces "A_2"
+   *   ; <local-newname; debug> "b"        // produces "b_0"
+   *   ; <local-newname; debug> "b"        // produces "b_1"
+   *   ; <local-newname; debug> "b_2"      // produces "b_2_0"
+   *   ; <local-newname; debug> "b_2"      // produces "b_2_1"
+   *   ; <local-newname; debug> "b_a"      // produces "b_a_0"
+   *   ; <local-newname; debug> "b_a"      // produces "b_a_1"
+   *   ; <local-newname; debug> "a_"       // produces "a__0"
+   *   ; <local-newname; debug> "a_1"      // produces "a_1_0"
    *   )
    */
   local-newname = local-newname(|())
@@ -61,11 +61,11 @@ strategies
    * locally unique names are generated, but with a different context term the counter for the
    * prefix resets. The default context used by `local-newname`/0 is `()`. 
    */
-  local-newname(|context): prefix -> $[[prefix][number]]
-      where key := <lower-case> prefix
+  local-newname(|context): prefix -> $[[prefix]_[number]]
+      where key := (context, <lower-case> prefix)
           ; number := <LocalNew <+ !0> key
           ; number' := <int-add(|1)> number
-          ; rules(LocalNew: (context, key) -> number')
+          ; rules(LocalNew: key -> number')
 
   /**
    * Generates a locally unique new string of the form 'c_d',
@@ -104,7 +104,7 @@ strategies
    */
   local-new(|context) =
     // use LocalNewAlpha to shift from ASCII character a to some letter in the alphabet
-    ![<int-add(|<LocalNewAlpha>)> 'a', '_']
+    ![<int-add(|<LocalNewAlpha>)> 'a']
     // Update LocalNewAlpha with increment modulo 26
   ; where(LocalNewAlpha; int-add(|1); if int-gt(|25) then !0 end; ?alpha; rules(LocalNewAlpha := alpha))
     // implode the letter + underscore list of characters to a string

--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -36,12 +36,13 @@ strategies
    *
    * The prefix comes in front of an increasing number, which is
    * separately maintained and started at 0 for each prefix.
+   * The numbering is case-insensitive on the prefix. 
    *
    * Examples (results are shown in comment)
    *   scope-local-new(
    *     <local-newname; debug> "a"        // produces "a0"
    *   ; <local-newname; debug> "a"        // produces "a1"
-   *   ; <local-newname; debug> "a"        // produces "a2"
+   *   ; <local-newname; debug> "A"        // produces "A2"
    *   ; <local-newname; debug> "b"        // produces "b0"
    *   ; <local-newname; debug> "b"        // produces "b1"
    *   ; <local-newname; debug> "b_2"      // produces "b_20"
@@ -53,9 +54,10 @@ strategies
    *   )
    */
   local-newname: prefix -> $[[prefix][number]]
-  where number := <LocalNew <+ !0> prefix
+  where key := <lower-case> prefix
+      ; number := <LocalNew <+ !0> key
       ; number' := <int-add(|1)> number
-      ; rules(LocalNew: prefix -> number')
+      ; rules(LocalNew: key -> number')
 
   /**
    * Generates a locally unique new string of the form 'c_d',

--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -88,7 +88,7 @@ strategies
    *   ; <local-new; debug>          // produces "i_0"
    *   ; <local-new; debug>          // produces "j_0"
    *   ; <local-new; debug>          // produces "k_0"
-   *   ; <local-newname; debug> "f_" // produces "f_1"
+   *   ; <local-newname; debug> "f"  // produces "f_1"
    *   )
    * Note how the input to local-new is ignored. It does share
    * information with local-newname so the two don't generate

--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -67,18 +67,18 @@ strategies
    *
    * Examples (results are shown in comment)
    *   scope-local-new(
-   *     <local-new; debug> "a"        // produces "a_0"
-   *   ; <local-new; debug> "a"        // produces "b_0"
-   *   ; <local-new; debug> "a"        // produces "c_0"
-   *   ; <local-new; debug> "b"        // produces "d_0"
-   *   ; <local-new; debug> "b"        // produces "e_0"
-   *   ; <local-new; debug> "b_2"      // produces "f_0"
-   *   ; <local-new; debug> "b_2"      // produces "g_0"
-   *   ; <local-new; debug> "b_a"      // produces "h_0"
-   *   ; <local-new; debug> "b_a"      // produces "i_0"
-   *   ; <local-new; debug> "a_"       // produces "j_0"
-   *   ; <local-new; debug> "a_1"      // produces "k_0"
-   *   ; <local-newname; debug> "f_"   // produces "f_1"
+   *     <local-new; debug>          // produces "a_0"
+   *   ; <local-new; debug>          // produces "b_0"
+   *   ; <local-new; debug>          // produces "c_0"
+   *   ; <local-new; debug>          // produces "d_0"
+   *   ; <local-new; debug>          // produces "e_0"
+   *   ; <local-new; debug>          // produces "f_0"
+   *   ; <local-new; debug>          // produces "g_0"
+   *   ; <local-new; debug>          // produces "h_0"
+   *   ; <local-new; debug>          // produces "i_0"
+   *   ; <local-new; debug>          // produces "j_0"
+   *   ; <local-new; debug>          // produces "k_0"
+   *   ; <local-newname; debug> "f_" // produces "f_1"
    *   )
    * Note how the input to local-new is ignored. It does share
    * information with local-newname so the two don't generate

--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -64,6 +64,25 @@ strategies
    * scope-local-new, and only based on previous calls to
    * local-newname/local-new. If you constructed a similar name by
    * hand it will not be avoided.
+   *
+   * Examples (results are shown in comment)
+   *   scope-local-new(
+   *     <local-new; debug> "a"        // produces "a_0"
+   *   ; <local-new; debug> "a"        // produces "b_0"
+   *   ; <local-new; debug> "a"        // produces "c_0"
+   *   ; <local-new; debug> "b"        // produces "d_0"
+   *   ; <local-new; debug> "b"        // produces "e_0"
+   *   ; <local-new; debug> "b_2"      // produces "f_0"
+   *   ; <local-new; debug> "b_2"      // produces "g_0"
+   *   ; <local-new; debug> "b_a"      // produces "h_0"
+   *   ; <local-new; debug> "b_a"      // produces "i_0"
+   *   ; <local-new; debug> "a_"       // produces "j_0"
+   *   ; <local-new; debug> "a_1"      // produces "k_0"
+   *   ; <local-newname; debug> "f_"   // produces "f_1"
+   *   )
+   * Note how the input to local-new is ignored. It does share
+   * information with local-newname so the two don't generate
+   * overlapping names within the same scope-local-new call.
    */
   local-new =
     ![<int-add(|<LocalNewAlpha>)> 'a', '_']

--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -53,11 +53,19 @@ strategies
    *   ; <local-newname; debug> "a_1"      // produces "a_10"
    *   )
    */
-  local-newname: prefix -> $[[prefix][number]]
-  where key := <lower-case> prefix
-      ; number := <LocalNew <+ !0> key
-      ; number' := <int-add(|1)> number
-      ; rules(LocalNew: key -> number')
+  local-newname = local-newname(|())
+
+  /**
+   * This version of local-newname uses the given context term as a "reentrant scope".
+   * When given the same context term and name (within the same `scope-local-new` call), new
+   * locally unique names are generated, but with a different context term the counter for the
+   * prefix resets. The default context used by `local-newname`/0 is `()`. 
+   */
+  local-newname(|context): prefix -> $[[prefix][number]]
+      where key := <lower-case> prefix
+          ; number := <LocalNew <+ !0> key
+          ; number' := <int-add(|1)> number
+          ; rules(LocalNew: (context, key) -> number')
 
   /**
    * Generates a locally unique new string of the form 'c_d',
@@ -86,7 +94,15 @@ strategies
    * information with local-newname so the two don't generate
    * overlapping names within the same scope-local-new call.
    */
-  local-new =
+  local-new = local-new(|())
+
+  /**
+   * This version of local-new uses the given context term as a "reentrant scope".
+   * When given the same context term (within the same `scope-local-new` call), new locally unique
+   * names are generated, but with a different context term the counter resets. The default context
+   * used by `local-newname`/0 is `()`. 
+   */
+  local-new(|context) =
     // use LocalNewAlpha to shift from ASCII character a to some letter in the alphabet
     ![<int-add(|<LocalNewAlpha>)> 'a', '_']
     // Update LocalNewAlpha with increment modulo 26
@@ -94,7 +110,7 @@ strategies
     // implode the letter + underscore list of characters to a string
   ; implode-string
     // apply local-newname to share information and not produce overlapping names between the two
-  ; local-newname
+  ; local-newname(|context)
 
   /**
    * @deprecated: Please use locally scoped new/newname instead.

--- a/strategoxt/stratego-libraries/lib/spec/term/string.str
+++ b/strategoxt/stratego-libraries/lib/spec/term/string.str
@@ -22,12 +22,74 @@ imports
 strategies
 
   /**
+   * Scopes local-newname and local-new, which work by dynamic rule.
+   */
+  scope-local-new(s) = {| LocalNew, LocalNewAlpha : rules(LocalNewAlpha := 0);  s |}
+
+  /**
+   * Generates a locally unique new string with user-defined prefix
+   * the form 'sd', where s is a string and d is a positive integer.
+   * The produced string is *only* unique within the scope of
+   * scope-local-new, and only based on previous calls to
+   * local-newname/local-new. If you constructed a similar name by
+   * hand it will not be avoided.
+   *
+   * The prefix comes in front of an increasing number, which is
+   * separately maintained and started at 0 for each prefix.
+   *
+   * Examples (results are shown in comment)
+   *   scope-local-new(
+   *     <local-newname; debug> "a"        // produces "a0"
+   *   ; <local-newname; debug> "a"        // produces "a1"
+   *   ; <local-newname; debug> "a"        // produces "a2"
+   *   ; <local-newname; debug> "b"        // produces "b0"
+   *   ; <local-newname; debug> "b"        // produces "b1"
+   *   ; <local-newname; debug> "b_2"      // produces "b_20"
+   *   ; <local-newname; debug> "b_2"      // produces "b_21"
+   *   ; <local-newname; debug> "b_a"      // produces "b_a0"
+   *   ; <local-newname; debug> "b_a"      // produces "b_a1"
+   *   ; <local-newname; debug> "a_"       // produces "a_0"
+   *   ; <local-newname; debug> "a_1"      // produces "a_10"
+   *   )
+   */
+  local-newname: prefix -> $[[prefix][number]]
+  where number := <LocalNew <+ !0> prefix
+      ; number' := <int-add(|1)> number
+      ; rules(LocalNew: s -> number')
+
+  /**
+   * Generates a locally unique new string of the form 'c_d',
+   * where c is one char and d is a positive integer.
+   * The produced string is *only* unique within the scope of
+   * scope-local-new, and only based on previous calls to
+   * local-newname/local-new. If you constructed a similar name by
+   * hand it will not be avoided.
+   */
+  local-new =
+    ![<int-add(|<LocalNewAlpha>)> 'a', '_']
+  ; where(LocalNewAlpha; int-add(|1); if int-gt(|25) then !0 end; ?alpha; rules(LocalNewAlpha := alpha))
+  ; implode-string
+  ; local-newname
+
+  /**
+   * @deprecated: Please use locally scoped new/newname instead.
+   * This primitive is bad for deterministic and separate compilation
+   * and is very difficult and costly to support. Currently may break
+   * its uniqueness guarantee due to garbage collection on the JVM at
+   * and inopportune time.
+   *
    * Generates a unique new string of the form 'c_d',
    * where c is one char and d is a positive integer.
    */
   new = prim("SSL_new")
 
   /**
+   * @deprecated: Please use locally scoped new/newname instead.
+   * This primitive is bad for deterministic and separate compilation
+   * and is very difficult and costly to support. Currently may break
+   * its uniqueness guarantee due to garbage collection on the JVM at
+   * and inopportune time.
+   *
    * Generates a unique new string with user-defined prefix
    * the form 'sd', where s is a string and d is a positive integer.
    * The produced string is *always* unique across a program run.


### PR DESCRIPTION
I quickly wrote an implementation of a local new/newname based on dynamic rules after our discussion about why everything is terrible with the normal new/newname. It's fairly simple but I didn't really test it. I'm not sure the standard library tests are even executed any more, so I'm not sure it's much help to write unit tests. But at least with a PR like this you can have a look too before we actually commit something new to the standard library. (Meanwhile I'll see if I can test it locally)