### PR TITLE
Inline duplicate strategy `get-max-term-size-config`

### DIFF
--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/pp/stratego2abox.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/pp/stratego2abox.str
@@ -1003,10 +1003,14 @@ rules
     where
       <separate-by-comma> exprs => args
 
+overlays
+
+  MaxTermSize() = 15
+
 rules
 
   worstcase-nicecase(worstcase,nicecase) =
-    where(<gt> (<term-size>, !15))
+    where(<gt> (<term-size>, MaxTermSize()))
   < worstcase
   + nicecase
 

--- a/strategoxt/stratego-libraries/strc/lib/stratego/strc/pp/stratego2abox.str
+++ b/strategoxt/stratego-libraries/strc/lib/stratego/strc/pp/stratego2abox.str
@@ -274,8 +274,6 @@ rules
     ListVar(name) -> name
 
 rules
-  
-  get-max-term-size-config = !15
 
   stratego-to-abox =
     ( ?Op(f,[x | xs]) + ?CongQ(f,[x | xs]) + ?OpQ(f,[x|xs]) )
@@ -1008,7 +1006,7 @@ rules
 rules
 
   worstcase-nicecase(worstcase,nicecase) =
-    where(<gt> (<term-size>, <get-max-term-size-config>))
+    where(<gt> (<term-size>, !15))
   < worstcase
   + nicecase
 


### PR DESCRIPTION
The duplicate strategy was causing warnings during building, like:
```
[INFO] [ strj | warning ] multiple external definitions with same signature
[INFO]           [ExtSDef("get-max-term-size-config",[],[]),ExtSDef("get-max-term-size-config",[],[])]
```
I found the second definition of this strategy at:
https://github.com/metaborg/strategoxt/blob/master/strategoxt/stratego-libraries/aterm/lib/stratego/aterm/PrettyPrint.str#L46

By `grep`ping through the entire code base of Spoofax, I found no other use of these strategies, so I decided to inline the simpler one of them.
Let me know if this would cause any trouble, since I have no clue about this ancient part of the code base :joy: