### PR TITLE
Close class loaders when HybridInterpreter is uninit'ed.

### DIFF
--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/HybridInterpreter.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/HybridInterpreter.java
@@ -78,6 +78,8 @@ public class HybridInterpreter extends Interpreter implements IAsyncCancellable 
 
 	private final ConstructorRecordingTermFactory recordingFactory;
 
+	private final ArrayList<URLClassLoader> classLoaders = new ArrayList<>();
+
 	private static class ConstructorRecordingTermFactory extends AbstractWrappedTermFactory {
 
 		private final Collection<IStrategoConstructor> constructors = new ArrayList<IStrategoConstructor>();
@@ -284,6 +286,7 @@ public class HybridInterpreter extends Interpreter implements IAsyncCancellable 
 			throws SecurityException, NoInteropRegistererJarException, IncompatibleJarException, IOException {
 
 		URLClassLoader classLoader = new URLClassLoader(jars, parentClassLoader);
+		classLoaders.add(classLoader);
 		boolean foundRegisterer = false;
 		loadedJars = true;
 
@@ -385,6 +388,15 @@ public class HybridInterpreter extends Interpreter implements IAsyncCancellable 
 		SSLLibrary lib = SSLLibrary.instance(getContext());
 		if (lib != null)
 			lib.getIOAgent().closeAllFiles();
+		try {
+			for(URLClassLoader classLoader : classLoaders) {
+				classLoader.close();
+			}
+		} catch(IOException e) {
+			throw new RuntimeException(e);
+		} finally {
+			classLoaders.clear();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue (mainly on Windows) where JAR files cannot be modified/deleted, because they are still loaded by a `URLClassLoader`. Spoofax Core's `StrategoRuntimeService` calls `uninit` when it is closed.

Keeping references to `URLClassLoader` does not introduce additional overhead, as loaded classes also have a reference to the classloader.