### PR TITLE
Replace C-style term type integer checks with TermType enum

### DIFF
--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_at_end_1_0.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_at_end_1_0.java
@@ -1,11 +1,11 @@
 package org.strategoxt.lang;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.*;
 import static org.strategoxt.lang.Term.*;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.interpreter.terms.TermType;
 
 /**
  * A stack-efficient version of the at-end strategy,
@@ -25,7 +25,7 @@ public class SRTS_EXT_at_end_1_0 extends Strategy {
 		//if (StackSaver.isNeededFor(context))
 		//	new StackSaver(this).invokeStackFriendly(context, current, new Strategy[] { s }, NO_TERMS);
 		
-		if (current.getTermType() != LIST)
+		if (current.getType() != TermType.LIST)
 			return null;
 		
 		IStrategoList list = (IStrategoList) current;

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_concat_0_0.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_concat_0_0.java
@@ -1,12 +1,11 @@
 package org.strategoxt.lang;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.*;
-
 import java.util.LinkedList;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.interpreter.terms.TermType;
 
 /**
  * A stack-efficient version of the concat strategy, which concatenates
@@ -26,7 +25,7 @@ public class SRTS_EXT_concat_0_0 extends Strategy {
 	
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm current) {
-	    if (current.getTermType() != LIST) {
+	    if (current.getType() != TermType.LIST) {
 	        return null;
 	    }
 	    ITermFactory factory = context.getFactory();
@@ -36,7 +35,7 @@ public class SRTS_EXT_concat_0_0 extends Strategy {
 	    // Build a doubly linked list with the terms. O(n)
 	    LinkedList<IStrategoTerm> tempList = new LinkedList<IStrategoTerm>();
 	    for (IStrategoTerm t : list) {
-	    	if (t.getTermType() != LIST) {
+	    	if (t.getType() != TermType.LIST) {
 				// The term must be a list...
 				return null;
 	    	}

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_fatal_err_0_3.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_fatal_err_0_3.java
@@ -1,10 +1,10 @@
 package org.strategoxt.lang;
 
 import static org.spoofax.interpreter.core.Tools.*;
-import static org.spoofax.interpreter.terms.IStrategoTerm.*;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.TermType;
 import org.strategoxt.stratego_lib.concat_strings_0_0;
 
 /**
@@ -15,16 +15,16 @@ public class SRTS_EXT_fatal_err_0_3 extends Strategy {
 	
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm current, IStrategoTerm message, IStrategoTerm term, IStrategoTerm trace) {
-		if (message.getTermType() == LIST)
+		if (message.getType() == TermType.LIST)
 			message = concat_strings_0_0.instance.invoke(context, message);
-		if (message == null || message.getTermType() != STRING)
+		if (message == null || message.getType() != TermType.STRING)
 			return null;
 		
 		context.popOnExit(false);
-		if (term.getTermType() == TUPLE && term.getSubtermCount() == 0) {
+		if (term.getType() == TermType.TUPLE && term.getSubtermCount() == 0) {
 			throw new StrategoErrorExit(asJavaString(message));
 		} else {
-			if(trace.getTermType() == LIST){
+			if(trace.getType() == TermType.LIST){
 				throw new StrategoErrorExit(asJavaString(message), term, (IStrategoList) trace);
 			}else{
 				throw new StrategoErrorExit(asJavaString(message), term);

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_filter_1_0.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_filter_1_0.java
@@ -2,6 +2,7 @@ package org.strategoxt.lang;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.TermType;
 
 /**
  * An implementation of filter(s), optimized for stack behavior
@@ -17,7 +18,7 @@ public class SRTS_EXT_filter_1_0 extends Strategy {
 	
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm current, Strategy s) {
-		if (current.getTermType() != IStrategoTerm.LIST)
+		if (current.getType() != TermType.LIST)
 			return null;
 		
 		IStrategoList list = (IStrategoList) current;

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_flatten_list_0_0.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_EXT_flatten_list_0_0.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.TermType;
 import org.strategoxt.lang.Context;
 import org.strategoxt.lang.Strategy;
 
@@ -29,19 +30,19 @@ public class SRTS_EXT_flatten_list_0_0 extends Strategy {
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm current) {
 
-		if (current.getTermType() != IStrategoTerm.LIST) {
+		if (current.getType() != TermType.LIST) {
 			return null;
 		}
 
-		ArrayList<IStrategoTerm> newList = new ArrayList<IStrategoTerm>();
-		ArrayList<IStrategoTerm> stack = new ArrayList<IStrategoTerm>();
+		ArrayList<IStrategoTerm> newList = new ArrayList<>();
+		ArrayList<IStrategoTerm> stack = new ArrayList<>();
 
 		stack.add(current);
 
 		while (!stack.isEmpty()) {
 			current = stack.remove(stack.size() - 1);
 
-			if (current.getTermType() == IStrategoTerm.LIST) {
+			if (current.getType() == TermType.LIST) {
 				IStrategoList list = (IStrategoList)current;
 				final int oldsize = stack.size();
 				while (!list.isEmpty()) {

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_all.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_all.java
@@ -1,11 +1,6 @@
 package org.strategoxt.lang;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.*;
-
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.*;
 
 /**
  * @author Lennart Kats <lennart add lclnet.nl>
@@ -15,9 +10,9 @@ public class SRTS_all extends Strategy {
 
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm current, Strategy s) {
-		int termType = current.getTermType();
+		TermType termType = current.getType();
 		
-		if (termType == LIST) {
+		if (termType == TermType.LIST) {
 			IStrategoList list = (IStrategoList) current;
 			return mapMaintainAnnos(context, list, s, noAnnosTail(list));
 		} else {

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_one.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_one.java
@@ -1,11 +1,10 @@
 package org.strategoxt.lang;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.*;
-
 import org.spoofax.interpreter.terms.IStrategoAppl;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.TermType;
 
 /**
  * @author Lennart Kats <lennart add lclnet.nl>
@@ -15,9 +14,9 @@ public class SRTS_one extends Strategy {
 
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm current, Strategy s) {
-		int termType = current.getTermType();
+		TermType termType = current.getType();
 		
-		if (termType == LIST)
+		if (termType == TermType.LIST)
 			return fetchMaintainAnnos(context, (IStrategoList) current, s);
 		
 		IStrategoTerm[] results = null;

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_some.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/SRTS_some.java
@@ -1,11 +1,10 @@
 package org.strategoxt.lang;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.*;
-
 import org.spoofax.interpreter.terms.IStrategoAppl;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.TermType;
 
 /**
  * @author Lennart Kats <lennart add lclnet.nl>
@@ -15,9 +14,9 @@ public class SRTS_some extends Strategy {
 
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm current, Strategy s) {
-		int termType = current.getTermType();
+		TermType termType = current.getType();
 		
-		if (termType == LIST) {
+		if (termType == TermType.LIST) {
 			final IStrategoList list = (IStrategoList) current;
 			return map1MaintainAnnos(context, list, s, false, SRTS_all.noAnnosTail(list));
 		}

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/StrategoErrorExit.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/StrategoErrorExit.java
@@ -3,6 +3,7 @@ package org.strategoxt.lang;
 import org.spoofax.interpreter.core.Tools;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.TermType;
 
 /**
  * Exception thrown when the application exits with an fatal error message.
@@ -54,7 +55,7 @@ public class StrategoErrorExit extends StrategoExit {
             for(int i = 0; i < depth; i++) {
                 final IStrategoTerm t = trace.getSubterm(depth - i - 1);
                 sb.append("\n\t");
-                sb.append(t.getTermType() == IStrategoTerm.STRING ? Tools.asJavaString(t) : t);
+                sb.append(t.getType() == TermType.STRING ? Tools.asJavaString(t) : t);
             }
         }
         return sb.toString();

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/Term.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/Term.java
@@ -3,6 +3,7 @@ package org.strategoxt.lang;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.TermFactory;
 
 public class Term {
@@ -14,7 +15,7 @@ public class Term {
 	private Term() {}
 	
 	public static IStrategoList checkListTail(IStrategoTerm t) {
-		if(t.getTermType() != IStrategoTerm.LIST) {
+		if(t.getType() != TermType.LIST) {
 			System.err.println("Warning: trying to build list with illegal tail: " + t.toString());
 			    return null;
 		}
@@ -22,7 +23,7 @@ public class Term {
 	}
 
 	public static IStrategoList checkListAnnos(ITermFactory factory, IStrategoTerm annos) {
-		return annos.getTermType() != IStrategoTerm.LIST
+		return annos.getType() != TermType.LIST
 			? factory.makeList(annos)
 			: (IStrategoList) annos;
 	}

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/TermEqualityUtil.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/TermEqualityUtil.java
@@ -1,12 +1,5 @@
 package org.strategoxt.lang;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.APPL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.BLOB;
-import static org.spoofax.interpreter.terms.IStrategoTerm.INT;
-import static org.spoofax.interpreter.terms.IStrategoTerm.LIST;
-import static org.spoofax.interpreter.terms.IStrategoTerm.REAL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.STRING;
-import static org.spoofax.interpreter.terms.IStrategoTerm.TUPLE;
 import static org.strategoxt.lang.Term.NO_TERMS;
 
 import org.spoofax.interpreter.terms.IStrategoAppl;
@@ -17,6 +10,7 @@ import org.spoofax.interpreter.terms.IStrategoReal;
 import org.spoofax.interpreter.terms.IStrategoString;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.interpreter.terms.TermType;
 
 public class TermEqualityUtil {
 
@@ -30,8 +24,8 @@ public class TermEqualityUtil {
     public static boolean equalsIgnoreAnnos(IStrategoTerm t1, IStrategoTerm t2, ITermFactory factory) {
         if(t1 == t2)
             return true;
-        int termType = t1.getTermType();
-        int type2 = t2.getTermType();
+        TermType termType = t1.getType();
+        TermType type2 = t2.getType();
         if(termType != type2)
             return false;
 

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/compat/SSL_EXT_topdown_fputs.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/compat/SSL_EXT_topdown_fputs.java
@@ -1,11 +1,5 @@
 package org.strategoxt.lang.compat;
 
-import static org.spoofax.interpreter.core.Tools.asJavaInt;
-import static org.spoofax.interpreter.core.Tools.asJavaString;
-import static org.spoofax.interpreter.terms.IStrategoTerm.APPL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.INT;
-import static org.spoofax.interpreter.terms.IStrategoTerm.STRING;
-
 import java.io.IOException;
 import java.io.Writer;
 
@@ -14,6 +8,8 @@ import org.spoofax.interpreter.core.InterpreterException;
 import org.spoofax.interpreter.library.AbstractPrimitive;
 import org.spoofax.interpreter.library.ssl.SSLLibrary;
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.TermType;
+import org.spoofax.terms.util.TermUtils;
 
 /**
  * @author Lennart Kats <lennart add lclnet.nl>
@@ -31,10 +27,10 @@ public class SSL_EXT_topdown_fputs extends AbstractPrimitive {
 		
 		IStrategoTerm streamTerm = tvars[0];
 
-		if (streamTerm.getTermType() != APPL || streamTerm.getSubtermCount() != 1 || streamTerm.getSubterm(0).getTermType() != INT)
+		if (streamTerm.getType() != TermType.APPL || streamTerm.getSubtermCount() != 1 || streamTerm.getSubterm(0).getType() != TermType.INT)
 			return false;
 		
-		int streamInt = asJavaInt(streamTerm.getSubterm(0)); 
+		int streamInt = TermUtils.toJavaIntAt(streamTerm, 0);
 
 		SSLLibrary or = SSLLibrary.instance(env);
 		Writer writer = or.getIOAgent().getWriter(streamInt);
@@ -54,8 +50,8 @@ public class SSL_EXT_topdown_fputs extends AbstractPrimitive {
 			IStrategoTerm child = tree.getSubterm(i);
 			if (child.getSubtermCount() > 0) {
 				invoke(child, writer);
-			} else if (child.getTermType() == STRING) {
-				writer.write(asJavaString(child));
+			} else if (child.getType() == TermType.STRING) {
+				writer.write(TermUtils.toJavaString(child));
 			} 
 		}
 	}

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/compat/stratego_rtg_compat/strrtg_list_loop1_1_0.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/compat/stratego_rtg_compat/strrtg_list_loop1_1_0.java
@@ -2,6 +2,7 @@ package org.strategoxt.lang.compat.stratego_rtg_compat;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.TermType;
 import org.strategoxt.lang.Context;
 import org.strategoxt.lang.Strategy;
 
@@ -13,7 +14,7 @@ public class strrtg_list_loop1_1_0 extends Strategy {
 	
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm current, Strategy s) {
-		if (current.getTermType() != IStrategoTerm.LIST)
+		if (current.getType() != TermType.LIST)
 			return null;
 		
 		boolean success = false;			

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/compat/strc_compat/pp_c_0_0.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/compat/strc_compat/pp_c_0_0.java
@@ -1,11 +1,9 @@
 package org.strategoxt.lang.compat.strc_compat;
 
-import org.spoofax.interpreter.library.AbstractStrategoOperatorRegistry;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.terms.util.NotImplementedException;
 import org.strategoxt.lang.Context;
 import org.strategoxt.lang.Strategy;
-import org.strategoxt.lang.compat.StringValuePrimitive;
 
 /**
  * @author Lennart Kats <lennart add lclnet.nl>

--- a/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/parallel/stratego_parallel/ParallelAll.java
+++ b/strategoxt/stratego-libraries/java-backend/java/runtime/org/strategoxt/lang/parallel/stratego_parallel/ParallelAll.java
@@ -1,6 +1,5 @@
 package org.strategoxt.lang.parallel.stratego_parallel;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.*;
 import static org.strategoxt.lang.parallel.stratego_parallel.stratego_parallel.*;
 
 import java.util.WeakHashMap;
@@ -10,6 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.TermType;
 import org.strategoxt.lang.Context;
 import org.strategoxt.lang.SRTS_all;
 import org.strategoxt.lang.StrategoException;
@@ -161,7 +161,7 @@ public class ParallelAll extends SRTS_all {
 			return null;
 		}
 		
-		assert current.getTermType() == LIST;
+		assert current.getType() == TermType.LIST;
 		// TODO: return context.getFactory().replaceList(outputs, (IStrategoList) current);
 		return context.getFactory().makeList(outputs);
 	}
@@ -171,7 +171,7 @@ public class ParallelAll extends SRTS_all {
 	}
 	
 	protected boolean isCandidateTerm(Context context, IStrategoTerm term) {
-		if (term.getTermType() == LIST
+		if (term.getType() == TermType.LIST
 				&& term.getSubtermCount() >= subtermCountThreshold
 				&& getTermSize(term, 1) >= termSizeThreshold) {
 
@@ -206,7 +206,7 @@ public class ParallelAll extends SRTS_all {
 
 		int size = initialSize + subtermCount;
 		
-		if (term.getTermType() == LIST) {
+		if (term.getType() == TermType.LIST) {
 			for (IStrategoList cons = (IStrategoList) term; !cons.isEmpty(); cons = cons.tail()) {
 				IStrategoTerm subterm = cons.head();
 				size = getTermSize(subterm, size);


### PR DESCRIPTION
Depended on:
- metaborg/mb-rep#22

Apparently Stratego XT needs to be [bootstrapped first](https://buildfarm.metaborg.org/view/Spoofax/job/metaborg/job/spoofax-releng/job/master/429/) before it knows about `TermType`.